### PR TITLE
Libft lib2list compability fix

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -12,7 +12,7 @@
 
 MAINLIB = libft.a
 OCL_NAME = libocl.a
-SL_L_N = libstd.n libmtrx.n libvector.n libavl.n liblist.n libprintf.n lib2list.n #libhtable.n
+SL_L_N = libstd.n libmtrx.n libvector.n libavl.n lib2list.n liblist.n libprintf.n #libhtable.n
 SL_L_C = $(SL_L_N:.n=.clean)
 SL_L_F = $(SL_L_N:.n=.fclean)
 SL_L_R = $(SL_L_N:.n=.re)

--- a/libft/includes/libft.h
+++ b/libft/includes/libft.h
@@ -13,6 +13,7 @@
 #ifndef LIBFT_H
 # define LIBFT_H
 # include <stdlib.h>
+# include "ft_list.h"
 # include "get_next_line.h"
 # include "t_vec.h"
 # include "btavl.h"
@@ -20,7 +21,6 @@
 # include <unistd.h>
 # include <string.h>
 # include "ft_printf.h"
-# include "ft_list.h"
 //# include "t_list.h"
 # include "libstd.h"
 

--- a/libft/std_lib/lib2list/ft_lsttake.c
+++ b/libft/std_lib/lib2list/ft_lsttake.c
@@ -23,6 +23,8 @@ t_list_node	*ft_lsttake(t_list *lst)
 	lst->len -= 1;
 	res->next = NULL;
 	res->prev = NULL;
+	if (lst->begin)
+		lst->begin->prev = NULL;
 	if (lst->len == 0)
 		lst->end = NULL;
 	return (res);


### PR DESCRIPTION
Make more priority to lib2list module now Fellum's lists will be used by default. Also minor fix in ft_lsttake